### PR TITLE
 Update ucaresystem-core defective selective kernel removal 

### DIFF
--- a/ucaresystem-core
+++ b/ucaresystem-core
@@ -181,6 +181,31 @@ function MAINTENACE {
 		echo "Snap is not available on this system. Skipping."
 		sleep 1
 	fi
+
+# Function to check if Flatpak is installed
+check_flatpak_installed() {
+    if command -v flatpak &>/dev/null; then
+        echo "Flatpak is installed."
+        return 0
+    else
+        echo "Flatpak is not installed."
+        return 1
+    fi
+}
+
+# Function to update Flatpak packages
+update_flatpak_packages() {
+    if check_flatpak_installed; then
+        echo "Updating Flatpak packages..."
+        sudo flatpak update -y
+        echo "Flatpak packages updated successfully."
+    else
+        echo "Cannot update Flatpak packages because Flatpak is not installed."
+    fi
+}
+
+# Call the update_flatpak_packages function
+update_flatpak_packages
 	echo					
 	echo "####################################"
 	echo "Finished refreshing of Snap packages"

--- a/ucaresystem-core
+++ b/ucaresystem-core
@@ -250,6 +250,20 @@ update_flatpak_packages
 
 	sudo apt $APT_OPTS remove -y --purge $PURGE;
 
+# Function to remove a specific Linux image version
+function REMOVE_KERNEL {
+    local kernel_version="$1"
+    sudo apt-get remove -y --purge "linux-image-$kernel_version" "linux-headers-$kernel_version"
+}
+
+# Check if the user provided a kernel version
+if [[ "$1" == "-k" && ! -z "$2" ]]; then
+    kernel_version="$2"
+    REMOVE_KERNEL "$kernel_version"
+    echo "Removed Linux kernel version: $kernel_version"
+    exit 0
+fi
+
 	echo
 	echo "###################################"
 	echo "Finished removing old kernels"


### PR DESCRIPTION

Update ucaresystem-core defective selective kernel removal
This funcrtion is passed by ucaresystem-core -k linux-image-6.5.0-28-generic (to remove a defective or undesired kernel)

Function to remove a specific Linux image version

# Function to remove a specific Linux image version
function REMOVE_KERNEL {
    local kernel_version="$1"
    sudo apt-get remove -y --purge "linux-image-$kernel_version" "linux-headers-$kernel_version"
}

# Check if the user provided a kernel version
if [[ "$1" == "-k" && ! -z "$2" ]]; then
    kernel_version="$2"
    REMOVE_KERNEL "$kernel_version"
    echo "Removed Linux kernel version: $kernel_version"
    exit 0
fi