### PR TITLE
Revert "Update ucaresystem-core - add start snap after snaps Removing old revisions"

### DIFF
--- a/ucaresystem-core
+++ b/ucaresystem-core
@@ -181,22 +181,6 @@ function MAINTENACE {
 		echo "Snap is not available on this system. Skipping."
 		sleep 1
 	fi
-# Start previously stopped Snap applications
-echo "Starting previously stopped Snap applications..."
-for snapname in "${stopped_snaps[@]}"; do
-    sudo snap start "$snapname" &>/dev/null
-done
-
-# Print the names of started Snap applications
-if [ ${#stopped_snaps[@]} -gt 0 ]; then
-    echo "Started Snap applications:"
-    for snapname in "${stopped_snaps[@]}"; do
-        echo "$snapname"
-    done
-else
-    echo "No Snap applications were started."
-fi
-
 	echo					
 	echo "####################################"
 	echo "Finished refreshing of Snap packages"


### PR DESCRIPTION
Reverts Utappia/uCareSystem#38

Please check the log file I have attached.  It tries to restart snaps on a system that doesn't have snap.

P.S. Please test your code in a ubuntu VM before creating a pull request just in case we miss something 


[ucare-log.txt](https://github.com/Utappia/uCareSystem/files/15151066/ucare-log.txt)
