### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,4 +1,6 @@
 name: ShellCheck
+permissions:
+  contents: read
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 	System : Ubuntu Linux and derivatives. With Deb, Snap or Flatpak. (Partial support for Debian and WSL2) 
 	WebSite: http://utappia.org
 
-## Sponsors of the previous development cycle (v24.09)
+## Sponsors of the previous development cycle (v24.12)
 
 With version 24.06 of uCareSystem, I added a section to acknowledge the people who supported the development of the previous cycle. This addition was warmly received by the community, and I can't express enough gratitude to those who donated during the previous (v24.12) development cycle:
 

--- a/README.md
+++ b/README.md
@@ -11,26 +11,24 @@
 	Name   : uCareSystem
 	License: GPL3 (http://www.gnu.org/licenses/gpl.html)
 	Author : Salih Emin
-	Email  : salih-(a)-utappia.org
-	Date   : 24-12-2024 (first release 19-02-2009)
-	Version: 25.04.09
-	System : Ubuntu Linux and derivatives. With Deb, Snap or Flatpak. (Partial support for Debian and WSL2) 
+	Email  : salih-emin(a)ubuntu.com
+	Date   : 05-06-2025 (first release 19-02-2009)
+	Version: 25.06.05
+	System : Ubuntu Linux and derivatives. With Deb, Snap or Flatpak. (Partial support for WSL2) 
 	WebSite: http://utappia.org
 
-## Sponsors of the previous development cycle (v24.12)
+## Sponsors of the previous development cycle (v25.04)
 
-With version 24.06 of uCareSystem, I added a section to acknowledge the people who supported the development of the previous cycle. This addition was warmly received by the community, and I can't express enough gratitude to those who donated during the previous (v24.12) development cycle:
+With version 24.06 of uCareSystem, I added a section to acknowledge the people who supported the development of the previous cycle. This addition was warmly received by the community, and I can't express enough gratitude to those who donated during the previous development cycle:
 
 - P. Loughman (Thanks for your continued support)
 - D. Emge (Thanks for your continued support)
 - W. Schreinemachers (Thanks for your continued support)
 - W. Schwartz
-- O. Majila
-- N. Karanikolas
-- C. Alfaro
-- K. Leymann
-- M. Spinello
+- D. e Swarthout
 - D. Luchini
+- M. Stanley
+- N. Evangelista
 
 
 ## Description:

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ In summary, uCareSystem performs the following list of maintenance tasks automat
 - Removes Old Snap revisions to free up space
 - Downloads and installs Flatpak Package updates (It's skipped if Flatpak is not installed)
 - Removes unused Flatpak packages to free up space
-- Checks if there are older Linux kernels on the system and removes them. However it keeps the current and one previous version of the kernel.
+- Checks if there are older Linux kernels on the system and removes them. However it keeps the current and one previous version of the kernel. Also you can specify the number of kernels to keep
 - Cleans the cache of the downloaded packages
 - Removes obsolete packages
 - Removes orphan packages
 - Deletes package configuration files from packages that have been uninstalled by you
 - If there is a need for a system reboot, it will inform you and it will provide the list of packages that requested that system reboot
 
-![ucaresystem-core](https://github.com/user-attachments/assets/a684a40e-403f-4306-a4dc-930575e066c5)
+![ucaresystem-color](https://github.com/user-attachments/assets/6f5171c2-5a64-465b-b794-920e225ce7f7)
 
 ## Usage
 
@@ -74,6 +74,10 @@ ucaresystem-core -d
 If your Ubuntu (and official flavors) has reached the EOL support you can upgrade to the next supported release with `-eol`:
 ```
 ucaresystem-core -eol
+```
+You can specify if you need to keep more kernels and remove the rest
+```
+ucaresystem-core -k 3
 ```
 For information about all the available options / flags, start ucaresystem-core with `-h` option :
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ With version 24.06 of uCareSystem, I added a section to acknowledge the people w
 - M. Stanley
 - N. Evangelista
 
-
 ## Description:
 
 In summary, uCareSystem performs the following list of maintenance tasks automatically and without the need for user interference. :
@@ -74,11 +73,6 @@ If your Ubuntu (and official flavors) has reached the EOL support you can upgrad
 ```
 ucaresystem-core -eol
 ```
-You can specify if you need to keep more kernels and remove the rest
-```
-ucaresystem-core -k 3
-```
-
 For information about all the available options / flags, start ucaresystem-core with `-h` option :
 ```
 ucaresystem-core -h

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
  
 # uCareSystem
 
+	uCareSystem is an all-in-one system update and maintenance application for Ubuntu and its derivatives. It provides a simple way to keep your system up-to-date and clean.
+
 	Name   : uCareSystem
 	License: GPL3 (http://www.gnu.org/licenses/gpl.html)
 	Author : Salih Emin
@@ -49,6 +51,21 @@ In summary, uCareSystem performs the following list of maintenance tasks automat
 
 ![ucaresystem-color](https://github.com/user-attachments/assets/6f5171c2-5a64-465b-b794-920e225ce7f7)
 
+## Installation
+
+1. Download the latest .deb package from the [releases page](https://github.com/utappia/ucaresystem/releases)
+2. Install the package:
+   ```bash
+   sudo apt install ./ucaresystem-core_*.deb
+   ```
+The installer will:
+- Install the uCareSystem core package
+- Check if the Utappia repository exists in your system
+- If the repository is not found, it will automatically:
+  - Add the Utappia repository for future updates
+  - Add the repository signing key
+
+
 ## Usage
 
 uCareSystem creates a launcher icon in your Applications menu. Just search your applications menu for `ucare`. If you click the icon, it starts performing the default maintenance tasks. 
@@ -77,6 +94,27 @@ For information about all the available options / flags, start ucaresystem-core 
 ```
 ucaresystem-core -h
 ```
+## Uninstallation
+
+To completely remove uCareSystem and its repository:
+
+1. Remove the package:
+   ```bash
+   sudo apt autoremove ucaresystem-core
+   ```
+
+2. (Optional) Remove the repository and its signing key:
+   ```bash
+   sudo rm /etc/apt/sources.list.d/utappia*.list
+   sudo rm /etc/apt/keyrings/utappia*.gpg
+   ```
+   If you keep the repository and its signing key you can reinstall ucaresystem-core without downloading the *.deb package but instead by `apt install ucaresystem-core`.
+
+3. Update package lists:
+   ```bash
+   sudo apt update
+   ```
+
 ## Code contribution
 
 If you have an idea and want to contribute code:

--- a/assets/postinst
+++ b/assets/postinst
@@ -11,6 +11,8 @@ KEYSERVER="hkp://keyserver.ubuntu.com"
 KEY="EBC8F9FD"
 REPO_URL="http://ppa.launchpad.net/utappia/stable/ubuntu"
 REPO_FILE="/etc/apt/sources.list.d/utappia.list"
+KEYRING_DIR="/etc/apt/keyrings"
+KEYRING_FILE="$KEYRING_DIR/utappia-archive-keyring.gpg"
 
 # Distribution detection
 if [ -f /etc/os-release ]; then
@@ -31,7 +33,14 @@ if ls /etc/apt/sources.list.d/utappia* 1> /dev/null 2>&1; then
     echo "Utappia Repository exists... skipping"
 else
     echo "Adding Utappia public key"
-    apt-key adv --keyserver "$KEYSERVER" --keyserver-options no-ipv6 --recv-keys "$KEY"
+    # Create keyrings directory if it doesn't exist
+    mkdir -p "$KEYRING_DIR"
+    # Create GPG directory
+    mkdir -p /root/.gnupg
+    chmod 700 /root/.gnupg
+    # Download and install GPG key directly from keyserver
+    gpg --no-default-keyring --keyring "$KEYRING_FILE" --keyserver "$KEYSERVER" --recv-keys "$KEY"
+    chmod 644 "$KEYRING_FILE"
     echo ""
     
     echo "Adding Utappia repository"
@@ -61,8 +70,8 @@ else
     else
         cat <<EOT > "$REPO_FILE"
 # Debian compatible Utappia Repository
-deb $REPO_URL $COMPATIBLE_DIST_NAME main
-deb-src $REPO_URL $COMPATIBLE_DIST_NAME main
+deb [signed-by=$KEYRING_FILE] $REPO_URL $COMPATIBLE_DIST_NAME main
+deb-src [signed-by=$KEYRING_FILE] $REPO_URL $COMPATIBLE_DIST_NAME main
 EOT
         echo ""
         echo "Refreshing package list..."

--- a/ucaresystem-core
+++ b/ucaresystem-core
@@ -12,7 +12,7 @@ set -e
 # WebSite: http://utappia.org
 # Email  : salih-(at)-utappia.org
 # Date   : 11-12-2024 (first release 19-02-2009)
-# Version: 25.04.09
+# Version: 25.06.05
 # System : Ubuntu Linux and derivatives. With Deb, Snap or Flatpak. (Partial support for Debian and WSL2) 
 # Description:
 #This simple script will automatically refresh your package list, download and install
@@ -29,9 +29,9 @@ YELLOW="\e[33m"
 ENDCOLOR="\e[0m"
 DIST_CODENAME=$(lsb_release --codename | cut -f2)
 DATE=$(date +%F_%T)
-UCARE_VERSION="25.04.09"
-VER_CODENAME="P. Loughman"
-PREV_VER="24.12"
+UCARE_VERSION="25.06.05"
+VER_CODENAME="W. Schwartz"
+PREV_VER="25.04"
 USERNAME=$(logname 2>/dev/null || echo "$USER")
 DONATE="https://www.paypal.com/donate/?hosted_button_id=SATQ6Y9S3UCSG"
 # Check for root/sudo privileges
@@ -470,13 +470,11 @@ function GOODBYE {
 	echo " - P. Loughman"
 	echo " - D. Emge"
 	echo " - W. Schwartz"
-	echo " - O. Majila"
 	echo " - W. Schreinemachers"
-	echo " - N. Karanikolas"
-	echo " - C. Alfaro"
-	echo " - K. Leymann"
-	echo " - M. Spinello"
+	echo " - D. e Swarthout"
 	echo " - D. Luchini"
+	echo " - M. Stanley"
+	echo " - N. Evangelista"
 	echo ""
 	echo -e "${CYAN}$DONATE ${ENDCOLOR}"
 	echo ""

--- a/ucaresystem-core
+++ b/ucaresystem-core
@@ -10,7 +10,7 @@ set -e
 # License: GPL3 (http://www.gnu.org/licenses/gpl.html)
 # Author : Salih Emin
 # WebSite: http://utappia.org
-# Email  : salih-(at)-utappia.org
+# Email  : salih-emin(at)ubuntu.com
 # Date   : 11-12-2024 (first release 19-02-2009)
 # Version: 25.06.05
 # System : Ubuntu Linux and derivatives. With Deb, Snap or Flatpak. (Partial support for Debian and WSL2) 

--- a/ucaresystem-core
+++ b/ucaresystem-core
@@ -42,7 +42,7 @@ if [[ $EUID -ne 0 ]] ; then
 fi
 # Function to check internet connectivity
 function CHECK_INTERNET {
-    if curl -4 -s --head https://www.google.com | head -n 1 | grep "200 OK" > /dev/null; then
+    if curl -4 -s --head http://www.google.com | head -n 1 | grep "200 OK" > /dev/null; then
         return 0  # Internet connection is available
     else
         return 1  # No internet connection
@@ -107,7 +107,6 @@ function WELCOME_SCREEN {
 function CLEANUP_OLD_KERNELS {
     local keep_count=${1:-2}  # Default to keeping 2 kernels if not specified
     local current_kernel
-    local kernel_list
     local purge_list=""
     local min_kernels=2  # Minimum required: current + one backup
     
@@ -131,54 +130,35 @@ function CLEANUP_OLD_KERNELS {
     current_kernel=$(uname -r)
     echo -e "${YELLOW}Current kernel: ${current_kernel}${ENDCOLOR}"
     
-    # Find all installed kernels, sort by version
-    kernel_list=$(dpkg -l 'linux-image-*' | \
-        awk '/^ii/{ print $2 }' | \
-        sort -V)
+    # Build list of kernel packages to purge
+    # This uses the actual kernel files in /boot to determine which kernels to keep
+    purge_list=$(ls -tr /boot/vmlinuz-* | \
+        head -n -${keep_count} | \
+        grep -v "$current_kernel$" | \
+        cut -d- -f2- | \
+        awk '{print "linux-image-" $0 " linux-headers-" $0}')
     
-    # Count total installed kernels
-    total_kernels=$(echo "$kernel_list" | wc -l)
+    # Verify each package exists before adding to purge list
+    final_purge_list=""
+    for pkg in $purge_list; do
+        if dpkg-query -s "$pkg" >/dev/null 2>&1; then
+            final_purge_list="$final_purge_list $pkg"
+        fi
+    done
     
-    if [ "$total_kernels" -le "$keep_count" ]; then
-        echo -e "${YELLOW}No kernels eligible for removal (found $total_kernels, keeping $keep_count)${ENDCOLOR}"
+    if [ -z "$final_purge_list" ]; then
+        echo -e "${YELLOW}No kernels are eligible for removal${ENDCOLOR}"
         return 0
     fi
     
-    # Calculate how many kernels to remove
-    remove_count=$((total_kernels - keep_count))
+    echo -e "${YELLOW}The following kernels will be removed:${ENDCOLOR}"
+    echo "$final_purge_list"
+    echo
     
-    echo -e "${YELLOW}Found $total_kernels kernels, keeping $keep_count, will remove $remove_count${ENDCOLOR}"
+    # Remove the packages
+    sudo apt autoremove -y --purge $final_purge_list
     
-    # Build list of kernels to remove (oldest first)
-    # Explicitly exclude the running kernel
-    purge_list=$(echo "$kernel_list" | \
-        grep -v "$(uname -r)$" | \
-        head -n "$remove_count")
-    
-    if [ -n "$purge_list" ]; then
-        echo -e "${YELLOW}The following kernels will be removed:${ENDCOLOR}"
-        echo "$purge_list"
-        echo
-        
-        # Double check that running kernel is not in purge list
-        if echo "$purge_list" | grep -q "$(uname -r)"; then
-            echo -e "${YELLOW}ERROR: Safety check failed - current kernel was in remove list${ENDCOLOR}"
-            echo -e "${YELLOW}Aborting kernel cleanup to prevent system damage${ENDCOLOR}"
-            return 1
-        fi
-        
-        # For each kernel image, also remove its headers
-        for kernel in $purge_list; do
-            header_pkg=${kernel/image/headers}
-            if dpkg -l "$header_pkg" >/dev/null 2>&1; then
-                sudo apt remove -y --purge "$kernel" "$header_pkg"
-            else
-                sudo apt remove -y --purge "$kernel"
-            fi
-        done
-        
-        echo -e "${YELLOW} Kernel cleanup completed${ENDCOLOR}"Develop
-    fi
+    echo -e "${YELLOW}Kernel cleanup completed${ENDCOLOR}"
 }
 
 function MAINTENANCE {
@@ -440,14 +420,6 @@ function SHOW_HELP {
 		 -r --reboot       Reboot the system, after completing all the tasks, 
 
 		 -s --shutdown     Shutdown the system, after completing all the tasks, 
-
-		 -k --keep-kernels <number>
-			   Specify the number of kernels to keep during cleanup.
-			   Minimum value is 2 to ensure system stability
-			   (current kernel + backup). Default is 2 if not
-			   specified. The script will never remove the currently
-			   running kernel.
-			   Example: --keep-kernels 3 (keeps current + 2 older versions)
 EOF
 }
 
@@ -537,22 +509,6 @@ while [ "$1" != "" ]; do
 	-r | --reboot )		 WELCOME_SCREEN && MAINTENANCE && GOODBYE && RE_BOOT
 							 exit
 							    ;;
-        -k | --keep-kernels)
-            shift
-            if [ -n "$1" ] && [[ "$1" =~ ^[0-9]+$ ]]; then
-                min_kernels=2
-                if [ "$1" -lt "$min_kernels" ]; then
-                    echo -e "${YELLOW}Error: Cannot specify fewer than $min_kernels kernels${ENDCOLOR}"
-                    echo -e "${YELLOW}This ensures you always have a backup kernel${ENDCOLOR}"
-                    exit 1
-                fi
-                WELCOME_SCREEN && CLEANUP_OLD_KERNELS "$1" && GOODBYE
-            else
-                echo -e "${YELLOW}Error: --keep-kernels requires a positive number (minimum: 2)${ENDCOLOR}"
-                exit 1
-            fi
-            exit
-            ;;
         * )                  SHOW_HELP
                              exit 1
     esac

--- a/ucaresystem-core
+++ b/ucaresystem-core
@@ -42,7 +42,7 @@ if [[ $EUID -ne 0 ]] ; then
 fi
 # Function to check internet connectivity
 function CHECK_INTERNET {
-    if curl -4 -s --head http://archive.ubuntu.com | head -n 1 | grep "200 OK" > /dev/null; then
+    if curl -4 -s --head https://www.google.com | head -n 1 | grep "200 OK" > /dev/null; then
         return 0  # Internet connection is available
     else
         return 1  # No internet connection

--- a/ucaresystem-core
+++ b/ucaresystem-core
@@ -21,7 +21,7 @@ set -e
 #
 ## Script starts here
 
-#Variables
+# Variables
 GREEN="\e[32m"
 CYAN="\e[36m"
 MAGENTA="\e[35m"
@@ -40,6 +40,7 @@ if [[ $EUID -ne 0 ]] ; then
     exec sudo "$0" "$@" 
     exit 1
 fi
+
 # Function to check internet connectivity
 function CHECK_INTERNET {
     if curl -4 -s --head http://www.google.com | head -n 1 | grep "200 OK" > /dev/null; then
@@ -48,6 +49,7 @@ function CHECK_INTERNET {
         return 1  # No internet connection
     fi
 }
+
 # Check internet connectivity
 if ! CHECK_INTERNET; then
    echo -e "${YELLOW}No internet connection detected... ${ENDCOLOR}"
@@ -62,7 +64,7 @@ fi
 
 # Simple countdown function
 function COUNTDOWN {
-    secs=$1
+    local secs=$1
     while [ "$secs" -ge 0 ]; do
         if [ "$secs" -eq 0 ]; then
             # Clear the line completely and show just the "now!" message
@@ -108,6 +110,7 @@ function CLEANUP_OLD_KERNELS {
     local keep_count=${1:-2}  # Default to keeping 2 kernels if not specified
     local current_kernel
     local purge_list=""
+    local final_purge_list=""
     local min_kernels=2  # Minimum required: current + one backup
     
     echo -e "${GREEN}▸ Starting kernel cleanup...${ENDCOLOR}"
@@ -132,9 +135,11 @@ function CLEANUP_OLD_KERNELS {
     
     # Build list of kernel packages to purge
     # This uses the actual kernel files in /boot to determine which kernels to keep
-    purge_list=$(ls -tr /boot/vmlinuz-* | \
-        head -n -${keep_count} | \
-        grep -v "$current_kernel$" | \
+    purge_list=$(find /boot -maxdepth 1 -name "vmlinuz-*" -printf "%T@ %p\n" | \
+        sort -n | \
+        cut -d' ' -f2- | \
+        head -n -"${keep_count}" | \
+        grep -v "${current_kernel}$" | \
         cut -d- -f2- | \
         awk '{print "linux-image-" $0 " linux-headers-" $0}')
     
@@ -142,21 +147,21 @@ function CLEANUP_OLD_KERNELS {
     final_purge_list=""
     for pkg in $purge_list; do
         if dpkg-query -s "$pkg" >/dev/null 2>&1; then
-            final_purge_list="$final_purge_list $pkg"
+            final_purge_list="${final_purge_list} ${pkg}"
         fi
     done
     
-    if [ -z "$final_purge_list" ]; then
+    if [ -z "${final_purge_list}" ]; then
         echo -e "${YELLOW}No kernels are eligible for removal${ENDCOLOR}"
         return 0
     fi
     
     echo -e "${YELLOW}The following kernels will be removed:${ENDCOLOR}"
-    echo "$final_purge_list"
+    echo "${final_purge_list}"
     echo
     
     # Remove the packages
-    sudo apt autoremove -y --purge $final_purge_list
+    sudo apt autoremove -y --purge "${final_purge_list}"
     
     echo -e "${YELLOW}Kernel cleanup completed${ENDCOLOR}"
 }
@@ -172,13 +177,13 @@ function MAINTENANCE {
 	echo
 	df_output=$(df -h / | awk 'NR==2 {print "Percentage of disk space used:", $5, "\nFree space available:", $4}')
 	echo ""
-	echo -e "${YELLOW}$df_output ${ENDCOLOR}"
+	echo -e "${YELLOW}${df_output}${ENDCOLOR}"
 	echo
 	sleep 1
 
 	# The following is for when the unit file, source configuration file or drop-ins 
 	# of apt-news.service changed on disk and systemd wasn't aware of it.
-	if command -v systemctl &> /dev/null  && [ ! -f /proc/sys/fs/binfmt_misc/WSLInterop ]; then
+	if command -v systemctl &> /dev/null && [ ! -f /proc/sys/fs/binfmt_misc/WSLInterop ]; then
 		echo -e "${YELLOW}Reloading systemd manager configuration ${ENDCOLOR}"
 		sudo systemctl daemon-reload
 		sleep 1
@@ -339,7 +344,7 @@ function MAINTENANCE {
 	echo -e "${GREEN}▸ Checking Disk usage after System Maintenance ${ENDCOLOR}"
 	echo
 	df_output=$(df -h / | awk 'NR==2 {print "Percentage of disk space used:", $5, "\nFree space available:", $4}')
-	echo -e "${YELLOW}$df_output ${ENDCOLOR}"
+	echo -e "${YELLOW}${df_output}${ENDCOLOR}"
 	echo
 	sleep 1
 


### PR DESCRIPTION
Potential fix for [https://github.com/Utappia/uCareSystem/security/code-scanning/1](https://github.com/Utappia/uCareSystem/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions to `contents: read`, which is the minimum required for this workflow to function correctly. This ensures that the workflow does not inadvertently gain unnecessary write permissions.

The `permissions` block will be added immediately after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
