### PR TITLE
Robust Internet check

### DIFF
--- a/src/ucaresystem-core
+++ b/src/ucaresystem-core
@@ -230,17 +230,26 @@ function WAIT_FOR_PACKAGE_LOCKS {
 	local delay=${2:-5}
 	local attempt=1
 	local lock_files=(/var/lib/dpkg/lock /var/lib/dpkg/lock-frontend /var/lib/apt/lists/lock /var/cache/apt/archives/lock)
+	local locked_by=""
 
 	while [ "$attempt" -le "$retries" ]; do
-		: > /tmp/ucare_locks
-		sudo lsof "${lock_files[@]}" 2>/dev/null | sudo tee /tmp/ucare_locks > /dev/null
-		if [ -s /tmp/ucare_locks ]; then
-			echo -e "${YELLOW}▸ Package manager locks detected (attempt ${attempt}/${retries})${ENDCOLOR}"
-			cat /tmp/ucare_locks
+		locked_by=""
+		for lock_file in "${lock_files[@]}"; do
+			if [ -f "$lock_file" ]; then
+				# fuser exits 0 if the file is held, 1 if not; timeout prevents hangs
+				if timeout 5 fuser "$lock_file" >/dev/null 2>&1; then
+					locked_by="$lock_file"
+					break
+				fi
+			fi
+		done
+
+		if [ -n "$locked_by" ]; then
+			echo -e "${YELLOW}▸ Package manager lock detected on $locked_by (attempt ${attempt}/${retries})${ENDCOLOR}"
 			if [ "$attempt" -lt "$retries" ]; then
 				echo -e "${YELLOW}▸ Waiting ${delay}s for locks to clear...${ENDCOLOR}"
 				sleep "$delay"
-				attempt=$((attempt+1))
+				attempt=$((attempt + 1))
 				continue
 			fi
 			return 1

--- a/src/ucaresystem-core
+++ b/src/ucaresystem-core
@@ -69,38 +69,80 @@ else
 		DIST_CODENAME="unknown"
 	fi
 fi
-# Function to check internet connectivity
+
+# ---------------------------------------------------------------------------
+# CHECK_INTERNET — three-tier probe with retry
+#   Tier 1: HTTP HEAD via curl (or wget if curl absent)
+#   Tier 2: DNS resolution via getent
+#   Tier 3: Raw ICMP ping to well-known DNS servers
+# Returns 0 if any tier succeeds, 1 if all fail after MAX_ATTEMPTS attempts.
+# ---------------------------------------------------------------------------
 function CHECK_INTERNET {
     local SITES=("https://ubuntu.com" "https://google.com" "https://github.com" "https://cloudflare.com")
+    local DNS_HOSTS=("ubuntu.com" "google.com" "cloudflare.com")
+    local MAX_ATTEMPTS=2
+    local attempt
 
-    # Try several websites
-    for site in "${SITES[@]}"; do
-        if curl -4 -s --max-time 5 --connect-timeout 3 --head --fail "$site" >/dev/null; then
-            return 0  # Internet seems to work
+    for ((attempt=1; attempt<=MAX_ATTEMPTS; attempt++)); do
+
+        # Tier 1: HTTP/HTTPS connectivity
+        if command -v curl &>/dev/null; then
+            for site in "${SITES[@]}"; do
+                if curl -4 -s --max-time 5 --connect-timeout 3 --head --fail "$site" >/dev/null 2>&1; then
+                    return 0
+                fi
+            done
+        elif command -v wget &>/dev/null; then
+            for site in "${SITES[@]}"; do
+                if wget -q --spider --timeout=5 --tries=1 "$site" >/dev/null 2>&1; then
+                    return 0
+                fi
+            done
+        fi
+
+        # Tier 2: DNS resolution (works even if HTTP ports are blocked)
+        for host in "${DNS_HOSTS[@]}"; do
+            if getent hosts "$host" >/dev/null 2>&1; then
+                return 0
+            fi
+        done
+
+        # Tier 3: Raw ICMP — last resort (no DNS, no HTTP)
+        if ping -c 1 -W 2 1.1.1.1 &>/dev/null || ping -c 1 -W 2 8.8.8.8 &>/dev/null; then
+            return 0
+        fi
+
+        # Brief pause before retry (skipped on the final attempt)
+        if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+            sleep 2
         fi
     done
 
-    # If all HTTP checks failed, try a simple ping to a DNS server
-    if ping -c 1 -W 2 1.1.1.1 &>/dev/null || ping -c 1 -W 2 8.8.8.8 &>/dev/null; then
-        return 0  # Internet available (raw connectivity)
-    fi
-
-    # If everything failed, assume no internet
     return 1
 }
-# Check internet connectivity
-if ! CHECK_INTERNET; then
-   echo -e "${RED}✗ No internet connection detected... ${ENDCOLOR}"
-   sleep 1
-   echo ""
-   echo "  Please ensure that your system is connected to the internet,"
-   echo "  and then try again..." 
-   echo ""
-   echo -e "${GREEN}▸ Now I will just exit...${ENDCOLOR}" 1>&2
-   echo ""
-   sleep 2
-   exit 1
-fi
+
+# ---------------------------------------------------------------------------
+# REQUIRE_INTERNET — call this from any function that needs network access.
+# Exits the script with a clear message if connectivity is unavailable.
+# ---------------------------------------------------------------------------
+function REQUIRE_INTERNET {
+    echo -e "${GREEN}▸ Checking internet connectivity...${ENDCOLOR}"
+    if ! CHECK_INTERNET; then
+        echo -e "${RED}✗ No internet connection detected...${ENDCOLOR}"
+        sleep 1
+        echo ""
+        echo "  Please ensure that your system is connected to the internet,"
+        echo "  and then try again..."
+        echo ""
+        echo -e "${GREEN}▸ Now I will just exit...${ENDCOLOR}" 1>&2
+        echo ""
+        sleep 2
+        exit 1
+    fi
+    echo -e "${CYAN}✓ Internet connection confirmed${ENDCOLOR}"
+    sleep 1
+}
+
 # Simple countdown function
 function COUNTDOWN {
     local secs=$1
@@ -210,6 +252,9 @@ function WAIT_FOR_PACKAGE_LOCKS {
 
 # Pre-update health check
 function PREUPDATE_PREFLIGHT {
+	# All maintenance paths converge here — enforce connectivity once.
+	REQUIRE_INTERNET
+
 	echo
 	echo
 	echo -e "${MAGENTA} Started ${ENDCOLOR} "
@@ -637,6 +682,9 @@ function MAINTENANCE {
 }
 
 function UPGRADE_EOL_TO_NEXT {
+	# EOL upgrade path does not go through PREUPDATE_PREFLIGHT — check here.
+	REQUIRE_INTERNET
+
 	# Distribution check - Only works for Ubuntu
 	if [ ! -f /etc/os-release ]; then
 		echo -e "${RED}✗ Cannot detect distribution${ENDCOLOR}"
@@ -1000,6 +1048,20 @@ function RE_BOOT {
 		sudo reboot
 	fi
 }
+
+# ---------------------------------------------------------------------------
+# Pre-scan: flags that need no internet and no maintenance exit immediately.
+# This runs before the argument loop so SHOW_HELP / SHOW_VERSION are already
+# defined above and available. -x alone falls through to full maintenance as
+# intended; -x combined with -h/-v is also handled correctly here.
+# ---------------------------------------------------------------------------
+for _arg in "$@"; do
+    case "$_arg" in
+        -h|--help)    SHOW_HELP;    exit 0 ;;
+        -v|--version) SHOW_VERSION; exit 0 ;;
+    esac
+done
+unset _arg
 
 # The main process starts
 while [ "$1" != "" ]; do


### PR DESCRIPTION
Three concrete changes:

Improve CHECK_INTERNET — add a wget fallback if curl is absent, a DNS resolution tier between HTTP and ping, and 2 retry attempts with a brief gap before giving up

Add REQUIRE_INTERNET — a wrapper that calls CHECK_INTERNET and handles the exit messaging, callable from anywhere

Remove the top-level gate — put REQUIRE_INTERNET inside PREUPDATE_PREFLIGHT (all maintenance paths go through it) and inside UPGRADE_EOL_TO_NEXT (its own path); add a pre-scan before the while loop so --help and --version exit before anything network-related is even reached